### PR TITLE
Fixed Expose(name) to work as documented in the README. Tests included

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -31,9 +31,10 @@ export function Type(typeFunction?: (type?: TypeOptions) => Function) {
  * constructorToPlain and plainToConstructor transformations, however you can specify on which of transformation types
  * you want to skip this property.
  */
-export function Expose(options?: ExposeOptions) {
+export function Expose(options?: ExposeOptions|string) {
     return function(object: Object|Function, propertyName?: string) {
-        const metadata = new ExposeMetadata(object instanceof Function ? object : object.constructor, propertyName, options || {});
+        const metadata = new ExposeMetadata(object instanceof Function ? object : object.constructor, propertyName,
+            typeof options === "string" ? {name: options} : options || {});
         defaultMetadataStorage.addExposeMetadata(metadata);
     };
 }

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -1486,6 +1486,61 @@ describe("basic functionality", () => {
 
     });
 
+    it("should expose with alternative name if its given as a string parameter", () => {
+        defaultMetadataStorage.clear();
+
+        class User {
+
+            @Expose("myName")
+            firstName: string;
+
+            @Expose("secondName")
+            lastName: string;
+
+            @Exclude()
+            password: string;
+
+            @Expose()
+            get name(): string {
+                return this.firstName + " " + this.lastName;
+            }
+
+            @Expose("fullName")
+            getName(): string {
+                return this.firstName + " " + this.lastName;
+            }
+
+        }
+
+        const user = new User();
+        user.firstName = "Umed";
+        user.lastName = "Khudoiberdiev";
+        user.password = "imnosuperman";
+
+        const fromPlainUser = {
+            myName: "Umed",
+            secondName: "Khudoiberdiev",
+            password: "imnosuperman"
+        };
+
+        const plainUser: any = classToPlain(user);
+        plainUser.should.not.be.instanceOf(User);
+        plainUser.should.be.eql({
+            myName: "Umed",
+            secondName: "Khudoiberdiev",
+            name: "Umed Khudoiberdiev",
+            fullName: "Umed Khudoiberdiev"
+        });
+
+        const transformedUser = plainToClass(User, fromPlainUser);
+        transformedUser.should.be.instanceOf(User);
+        const likeUser = new User();
+        likeUser.firstName = "Umed";
+        likeUser.lastName = "Khudoiberdiev";
+        transformedUser.should.be.eql(likeUser);
+
+    });
+
     it("should exclude all prefixed properties if prefix is given", () => {
         defaultMetadataStorage.clear();
 


### PR DESCRIPTION
I saw that the way @Expose("name") is documented in the README doesn't actually work. This is just a simple fix with a test to verify it.
