### PR TITLE
Adding JsonView decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 node_modules/
 coverage/
 npm-debug.log
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -590,6 +590,55 @@ Now when you call `plainToClass` and send a plain representation of the Photo ob
 it will convert a date value in your photo object to moment date. 
 `@Transform` decorator also supports groups and versioning.
 
+## Other decorators
+| Signature          | Example                                  | Description
+|--------------------|------------------------------------------|---------------------------------------------|
+| `@TransformMethod` | `@TransformMethod({ groups: ["user"] })` | Transform the method return with classToPlain and expose the properties on the class.
+
+The `@TransformMethod` decorator accept 2 optional arguments.
+1. ClassTransformOptions - The transform options like groups, version, name
+2. the method to do the transform - classToPlain or classToClass
+
+An example:
+
+```
+@Exclude()
+class User {
+
+    id: number;
+
+    @Expose()
+    firstName: string;
+
+    @Expose()
+    lastName: string;
+
+    @Expose({ groups: ['user.email'] })
+    email: string;
+
+    password: string;
+}
+
+class UserController {
+    
+    @TransformMethod({ groups: ['user.email'] })
+    getUser() {
+        const user = new User();
+        user.firstName = "Snir";
+        user.lastName = "Segal";
+        user.password = "imnosuperman";
+
+        return user;
+    }
+}
+
+const controller = new UserController();
+const user = controller.getUser();
+```
+
+the `user` variable will contain only firstName,lastName, email properties becuase they are
+the exposed variables. email property is also exposed becuase we metioned the group "user.email".
+
 ## Working with generics
 
 Generics are not supported because TypeScript does not have good reflection abilities yet.

--- a/README.md
+++ b/README.md
@@ -593,15 +593,15 @@ it will convert a date value in your photo object to moment date.
 ## Other decorators
 | Signature          | Example                                  | Description
 |--------------------|------------------------------------------|---------------------------------------------|
-| `@TransformMethod` | `@TransformMethod({ groups: ["user"] })` | Transform the method return with classToPlain and expose the properties on the class.
+| `@TransformClassToPlain` | `@TransformClassToPlain({ groups: ["user"] })` | Transform the method return with classToPlain and expose the properties on the class.
+| `@TransformClassToClass` | `@TransformClassToClass({ groups: ["user"] })` | Transform the method return with classToClass and expose the properties on the class.
 
-The `@TransformMethod` decorator accept 2 optional arguments.
-1. ClassTransformOptions - The transform options like groups, version, name
-2. the method to do the transform - classToPlain or classToClass
+The above decorators accept one optional argument:
+ClassTransformOptions - The transform options like groups, version, name
 
 An example:
 
-```
+```typescript
 @Exclude()
 class User {
 
@@ -621,7 +621,7 @@ class User {
 
 class UserController {
     
-    @TransformMethod({ groups: ['user.email'] })
+    @TransformClassToPlain({ groups: ['user.email'] })
     getUser() {
         const user = new User();
         user.firstName = "Snir";

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -59,14 +59,13 @@ export function TransformClassToPlain(params?: ClassTransformOptions): Function 
 
     return function (target: Function, propertyKey: string, descriptor: PropertyDescriptor) {
         const classTransformer: ClassTransformer = new ClassTransformer();
-        const MethodTransformer: Function = classTransformer.classToPlain;
         const originalMethod = descriptor.value;
         
         descriptor.value = function(...args: any[]) {
             const result: any = originalMethod.apply(this, args);
             const isPromise = !!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function";          
 
-            return isPromise ? result.then((data: any) => MethodTransformer(data, params)) : MethodTransformer(result, params);
+            return isPromise ? result.then((data: any) => classTransformer.classToPlain(data, params)) : classTransformer.classToPlain(result, params);
         };
     };
 }
@@ -78,14 +77,13 @@ export function TransformClassToClass(params?: ClassTransformOptions): Function 
 
     return function (target: Function, propertyKey: string, descriptor: PropertyDescriptor) {
         const classTransformer: ClassTransformer = new ClassTransformer();
-        const MethodTransformer: Function = classTransformer.classToClass;
         const originalMethod = descriptor.value;
         
         descriptor.value = function(...args: any[]) {
             const result: any = originalMethod.apply(this, args);
             const isPromise = !!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function";
 
-            return isPromise ? result.then((data: any) => MethodTransformer(data, params)) : MethodTransformer(result, params);
+            return isPromise ? result.then((data: any) => classTransformer.classToClass(data, params)) : classTransformer.classToClass(result, params);
         };
     };
 }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -66,7 +66,7 @@ export function JsonView(params?: {}, method?: string): Function {
             
             if (!!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function") {
                 // If result is an instance of Promise.
-                return result.then((data: any) => transformer(result, params));
+                return result.then((data: any) => transformer(data, params));
             }
 
             result = transformer(result, params);

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -71,8 +71,7 @@ export function TransformMethod(params?: ClassTransformOptions, method?: "classT
                 case "classToClass":
                     transformer = classTransformer.classToClass;
                     break;
-                case "classToPlain":
-                default:
+                case "classToPlain": default:
                     transformer = classTransformer.classToPlain;
             }
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -64,13 +64,11 @@ export function JsonView(params?: {}, method?: string): Function {
             let transformer: Function = typeof method === "string" && method ? classTransformer[method] : classTransformer.classToPlain;
             let result: any = originalMethod.apply(this, args);
             
-            if (!!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function") {
-                // If result is an instance of Promise.
-                return result.then((data: any) => transformer(data, params));
-            }
+            let isPromise = !!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function";
 
-            result = transformer(result, params);
-            return result;
+            return isPromise ? 
+                result.then((data: any) => transformer(data, params)) : 
+                transformer(result, params);
         };
     };
 }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -62,14 +62,7 @@ export function JsonView(params?: {}, method?: string): Function {
 
         descriptor.value = function(...args: any[]) {
             let result: any = originalMethod.apply(this, args);
-
-            let transformer: Function;
-            if (typeof method === "string" && method) {
-                transformer = classTransformer[method];
-            }
-            else {
-                transformer = classTransformer.classToPlain;
-            }
+            let transformer: Function = typeof method === "string" && method ? classTransformer[method] : classTransformer.classToPlain;
 
             result = transformer(result, params);
             return result;

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -66,9 +66,7 @@ export function JsonView(params?: {}, method?: string): Function {
             
             if (!!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function") {
                 // If result is an instance of Promise.
-                return result.then((data: any) => {
-                    return transformer(result, params);
-                });
+                return result.then((data: any) => transformer(result, params));
             }
 
             result = transformer(result, params);

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -66,9 +66,7 @@ export function JsonView(params?: {}, method?: string): Function {
             
             let isPromise = !!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function";
 
-            return isPromise ? 
-                result.then((data: any) => transformer(data, params)) : 
-                transformer(result, params);
+            return isPromise ? result.then((data: any) => transformer(data, params)) : transformer(result, params);
         };
     };
 }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -64,7 +64,7 @@ export function JsonView(params?: {}, method?: string): Function {
             let transformer: Function = typeof method === "string" && method ? classTransformer[method] : classTransformer.classToPlain;
             let result: any = originalMethod.apply(this, args);
             
-            if (!!result && (typeof result === 'object' || typeof result === 'function') && typeof result.then === 'function') {
+            if (!!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function") {
                 // If result is an instance of Promise.
                 return result.then((data: any) => {
                     return transformer(result, params);

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -61,8 +61,15 @@ export function JsonView(params?: {}, method?: string): Function {
         const originalMethod = descriptor.value;
 
         descriptor.value = function(...args: any[]) {
-            let result: any = originalMethod.apply(this, args);
             let transformer: Function = typeof method === "string" && method ? classTransformer[method] : classTransformer.classToPlain;
+            let result: any = originalMethod.apply(this, args);
+            
+            if (!!result && (typeof result === 'object' || typeof result === 'function') && typeof result.then === 'function') {
+                // If result is an instance of Promise.
+                return result.then((data: any) => {
+                    return transformer(result, params);
+                });
+            }
 
             result = transformer(result, params);
             return result;

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,4 +1,4 @@
-import { ClassTransformer } from './ClassTransformer';
+import {ClassTransformer} from "./ClassTransformer";
 import {defaultMetadataStorage} from "./storage";
 import {TypeMetadata} from "./metadata/TypeMetadata";
 import {ExposeMetadata} from "./metadata/ExposeMetadata";
@@ -54,9 +54,9 @@ export function Exclude(options?: ExcludeOptions) {
 /**
  * Return the object with the exposed properties only.
  */
-export function JsonView(params: {}, method?: string): Function {
+export function JsonView(params?: {}, method?: string): Function {
 
-    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    return function (target: Function, propertyKey: string, descriptor: PropertyDescriptor) {
         const classTransformer: any = new ClassTransformer();
         const originalMethod = descriptor.value;
 
@@ -64,7 +64,7 @@ export function JsonView(params: {}, method?: string): Function {
             let result: any = originalMethod.apply(this, args);
 
             let transformer: Function;
-            if (typeof method === 'string' && method) {
+            if (typeof method === "string" && method) {
                 transformer = classTransformer[method];
             }
             else {
@@ -73,6 +73,6 @@ export function JsonView(params: {}, method?: string): Function {
 
             result = transformer(result, params);
             return result;
-        }
-    }
+        };
+    };
 }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,3 +1,4 @@
+import { ClassTransformer } from './ClassTransformer';
 import {defaultMetadataStorage} from "./storage";
 import {TypeMetadata} from "./metadata/TypeMetadata";
 import {ExposeMetadata} from "./metadata/ExposeMetadata";
@@ -48,4 +49,30 @@ export function Exclude(options?: ExcludeOptions) {
         const metadata = new ExcludeMetadata(object instanceof Function ? object : object.constructor, propertyName, options || {});
         defaultMetadataStorage.addExcludeMetadata(metadata);
     };
+}
+
+/**
+ * Return the object with the exposed properties only.
+ */
+export function JsonView(params: {}, method?: string): Function {
+
+    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+        const classTransformer: any = new ClassTransformer();
+        const originalMethod = descriptor.value;
+
+        descriptor.value = function(...args: any[]) {
+            let result: any = originalMethod.apply(this, args);
+
+            let transformer: Function;
+            if (typeof method === 'string' && method) {
+                transformer = classTransformer[method];
+            }
+            else {
+                transformer = classTransformer.classToPlain;
+            }
+
+            result = transformer(result, params);
+            return result;
+        }
+    }
 }

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -7,7 +7,7 @@ import {
     classToClass, classToClassFromExist
 } from "../../src/index";
 import {defaultMetadataStorage} from "../../src/storage";
-import {Exclude, Expose, Type, JsonView} from "../../src/decorators";
+import {Exclude, Expose, Type} from "../../src/decorators";
 import {expect} from "chai";
 
 describe("basic functionality", () => {
@@ -1679,48 +1679,6 @@ describe("basic functionality", () => {
 
         classToClassFromExistUser.should.be.eql([fromExistUserLike1, fromExistUserLike2]);
 
-    });
-    
-    it("should expose properties with json view", () => {
-        defaultMetadataStorage.clear();
-
-        @Exclude()
-        class User {
-
-            id: number;
-
-            @Expose()
-            firstName: string;
-
-            @Expose()
-            lastName: string;
-
-            password: string;
-        }
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-
-        const plainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        };
-
-        class UserController {
-            
-            @JsonView()
-            getUser() {
-                return user;
-            }
-        }
-        
-        const controller = new UserController();
-
-        let result = controller.getUser();
-        expect(result.password).to.be.undefined;
-        expect(result).to.be.eql(plainUser);
     });
 
 });

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -7,7 +7,7 @@ import {
     classToClass, classToClassFromExist
 } from "../../src/index";
 import {defaultMetadataStorage} from "../../src/storage";
-import {Exclude, Expose, Type} from "../../src/decorators";
+import {Exclude, Expose, Type, JsonView} from "../../src/decorators";
 import {expect} from "chai";
 
 describe("basic functionality", () => {
@@ -1679,6 +1679,48 @@ describe("basic functionality", () => {
 
         classToClassFromExistUser.should.be.eql([fromExistUserLike1, fromExistUserLike2]);
 
+    });
+    
+    it("should expose properties with json view", () => {
+        defaultMetadataStorage.clear();
+
+        @Exclude()
+        class User {
+
+            id: number;
+
+            @Expose()
+            firstName: string;
+
+            @Expose()
+            lastName: string;
+
+            password: string;
+        }
+
+        const user = new User();
+        user.firstName = "Umed";
+        user.lastName = "Khudoiberdiev";
+        user.password = "imnosuperman";
+
+        const plainUser = {
+            firstName: "Umed",
+            lastName: "Khudoiberdiev"
+        };
+
+        class UserController {
+            
+            @JsonView()
+            getUser() {
+                return user;
+            }
+        }
+        
+        const controller = new UserController();
+
+        let result = controller.getUser();
+        expect(result.password).to.be.undefined;
+        expect(result).to.be.eql(plainUser);
     });
 
 });

--- a/test/functional/transformer-method.spec.ts
+++ b/test/functional/transformer-method.spec.ts
@@ -1,9 +1,9 @@
 import "reflect-metadata";
 import {defaultMetadataStorage} from "../../src/storage";
-import {Exclude, Expose, TransformMethod} from "../../src/decorators";
+import {Exclude, Expose, TransformClassToPlain, TransformClassToClass} from "../../src/decorators";
 import {expect} from "chai";
 
-describe("transformer method decorator", () => {
+describe("transformer methods decorator", () => {
 
     it("should expose non configuration properties and return User instance class", () => {
         defaultMetadataStorage.clear();
@@ -24,7 +24,7 @@ describe("transformer method decorator", () => {
 
         class UserController {
             
-            @TransformMethod({}, "classToClass")
+            @TransformClassToClass()
             getUser() {
                 const user = new User();
                 user.firstName = "Snir";
@@ -69,7 +69,7 @@ describe("transformer method decorator", () => {
 
         class UserController {
             
-            @TransformMethod()
+            @TransformClassToPlain()
             getUser() {
                 const user = new User();
                 user.firstName = "Snir";
@@ -115,7 +115,7 @@ describe("transformer method decorator", () => {
 
         class UserController {
             
-            @TransformMethod({ groups: ["user.permissions"] })
+            @TransformClassToPlain({ groups: ["user.permissions"] })
             getUserWithRoles() {
                 const user = new User();
                 user.firstName = "Snir";
@@ -167,7 +167,7 @@ describe("transformer method decorator", () => {
 
         class UserController {
 
-            @TransformMethod({ version: 1 })
+            @TransformClassToPlain({ version: 1 })
             getUserVersion1() {
                 const user = new User();
                 user.firstName = "Snir";
@@ -179,7 +179,7 @@ describe("transformer method decorator", () => {
                 return user;
             }
                     
-            @TransformMethod({ version: 2 })
+            @TransformClassToPlain({ version: 2 })
             getUserVersion2() {
                 const user = new User();
                 user.firstName = "Snir";

--- a/test/functional/transformer-method.spec.ts
+++ b/test/functional/transformer-method.spec.ts
@@ -1,0 +1,223 @@
+import "reflect-metadata";
+import {defaultMetadataStorage} from "../../src/storage";
+import {Exclude, Expose, TransformMethod} from "../../src/decorators";
+import {expect} from "chai";
+
+describe("transformer method decorator", () => {
+
+    it("should expose non configuration properties and return User instance class", () => {
+        defaultMetadataStorage.clear();
+
+        @Exclude()
+        class User {
+
+            id: number;
+
+            @Expose()
+            firstName: string;
+
+            @Expose()
+            lastName: string;
+
+            password: string;
+        }
+
+        class UserController {
+            
+            @TransformMethod({}, "classToClass")
+            getUser() {
+                const user = new User();
+                user.firstName = "Snir";
+                user.lastName = "Segal";
+                user.password = "imnosuperman";
+
+                return user;
+            }
+        }
+
+        const controller = new UserController();
+
+        const result = controller.getUser();
+        expect(result.password).to.be.undefined;
+
+        const plainUser = {
+            firstName: "Snir",
+            lastName: "Segal"
+        };
+
+
+        expect(result).to.be.eql(plainUser);
+        expect(result).to.be.instanceof(User);
+    });
+
+    it("should expose non configuration properties", () => {
+        defaultMetadataStorage.clear();
+
+        @Exclude()
+        class User {
+
+            id: number;
+
+            @Expose()
+            firstName: string;
+
+            @Expose()
+            lastName: string;
+
+            password: string;
+        }
+
+        class UserController {
+            
+            @TransformMethod()
+            getUser() {
+                const user = new User();
+                user.firstName = "Snir";
+                user.lastName = "Segal";
+                user.password = "imnosuperman";
+
+                return user;
+            }
+        }
+
+        const controller = new UserController();
+
+        const result = controller.getUser();
+            expect(result.password).to.be.undefined;
+
+        const plainUser = {
+            firstName: "Snir",
+            lastName: "Segal"
+        };
+
+        expect(result).to.be.eql(plainUser);
+    });
+
+    it("should expose non configuration properties and properties with specific groups", () => {
+        defaultMetadataStorage.clear();
+
+        @Exclude()
+        class User {
+
+            id: number;
+
+            @Expose()
+            firstName: string;
+
+            @Expose()
+            lastName: string;
+
+            @Expose({ groups: ["user.permissions"] })
+            roles: string[];
+
+            password: string;
+        }
+
+        class UserController {
+            
+            @TransformMethod({ groups: ["user.permissions"] })
+            getUserWithRoles() {
+                const user = new User();
+                user.firstName = "Snir";
+                user.lastName = "Segal";
+                user.password = "imnosuperman";
+                user.roles = ["USER", "MANAGER"];
+
+                return user;
+            }
+
+        }
+
+        const controller = new UserController();
+
+        const result = controller.getUserWithRoles();
+        expect(result.password).to.be.undefined;
+
+        const plainUser = {
+            firstName: "Snir",
+            lastName: "Segal",
+            roles: ["USER", "MANAGER"]
+        };
+
+        expect(result).to.be.eql(plainUser);
+    });
+
+    it("should expose non configuration properties with specific version", () => {
+        defaultMetadataStorage.clear();
+
+        @Exclude()
+        class User {
+
+            id: number;
+
+            @Expose()
+            firstName: string;
+
+            @Expose()
+            lastName: string;
+
+            @Expose({ groups: ["user.permissions"] })
+            roles: string[];
+
+            @Expose({ since: 2 })
+            websiteUrl?: string;
+
+            password: string;
+        }
+
+        class UserController {
+
+            @TransformMethod({ version: 1 })
+            getUserVersion1() {
+                const user = new User();
+                user.firstName = "Snir";
+                user.lastName = "Segal";
+                user.password = "imnosuperman";
+                user.roles = ["USER", "MANAGER"];
+                user.websiteUrl = "http://www.github.com";
+
+                return user;
+            }
+                    
+            @TransformMethod({ version: 2 })
+            getUserVersion2() {
+                const user = new User();
+                user.firstName = "Snir";
+                user.lastName = "Segal";
+                user.password = "imnosuperman";
+                user.roles = ["USER", "MANAGER"];
+                user.websiteUrl = "http://www.github.com";
+
+                return user;
+            }
+
+        }
+
+        const controller = new UserController();
+
+        const resultV2 = controller.getUserVersion2();
+        expect(resultV2.password).to.be.undefined;
+        expect(resultV2.roles).to.be.undefined;
+
+        const plainUserV2 = {
+            firstName: "Snir",
+            lastName: "Segal",
+            websiteUrl: "http://www.github.com"
+        };
+
+        expect(resultV2).to.be.eql(plainUserV2);
+
+        const resultV1 = controller.getUserVersion1();
+        expect(resultV1.password).to.be.undefined;
+        expect(resultV1.roles).to.be.undefined;
+        expect(resultV1.websiteUrl).to.be.undefined;
+
+        const plainUserV1 = {
+            firstName: "Snir",
+            lastName: "Segal"
+        };
+
+        expect(resultV1).to.be.eql(plainUserV1);
+    });
+
+});


### PR DESCRIPTION
Adding @JsonView decorator so now it'll be possible to annotate a method in a controller class to expose the object properties.

Similar to JMS Serializer in Symfony (PHP) and in Java Spring.

Very useful with a library such - "ts-express-decorators" (https://github.com/Romakita/ts-express-decorators)

So it is more simpler to return a serialized object.

An example:

```
@Exclude()
class UserModel {
    @Expose()
    id: number;

    @Expose({name: 'first_name', groups: ['user.base'] })
    firstName: string;

    @Expose({ name: 'last_name', groups: ['user.base'] })
    lastName: string;

    @Expose({ groups: ['user.details'] })
    email: string;

    phone: string;
}

@Controller("/users")
export class UserController {

    constructor() {}

    @Get("/:id")
    @JsonView({groups: ['user.base']})
    public getDetails(
        @Request() request: Express.Request, 
        @Response() response: Express.Response,
        @Next() next: Express.NextFunction
    ): any {

        let user = new UserTest();
        user.id = 1;
        user.firstName = 'Snir';
        user.lastName = 'Segal';
        user.email = 'snirs@codeoasis.com';
        user.phone = '0523262583';

        return user;
    }
}
```
